### PR TITLE
get access to authenticate helper function; optional athorization header

### DIFF
--- a/com/coldfumonkeh/base.cfc
+++ b/com/coldfumonkeh/base.cfc
@@ -259,8 +259,37 @@ Revision history
 			return returnStruct;
 		</cfscript>
 	</cffunction>
-	
+
 	<!--- PUBLIC FUNCTIONS --->
+  <cffunction name="getAccessToAuthenticate" output="false" returntype="Struct" hint="Gets a Twitter access token via POST request which can be stored and used for future access.  Designed to have same function signature as coldfumunkeh's getAuthorisation().">
+    <cfargument name="callBackURL"	type="string" hint="The URL to hit on call back from authorisation" required="false" default="" />
+    <cfset var returnStruct = {}/>
+    <cfset returnStruct['success'] = false/>
+    <cfset var twitterAuthPoint = "https://api.twitter.com/oauth/authenticate"/>
+    <cfset var requestParameters = {}/>
+    <cfset requestParameters['oauth_callback'] = arguments.callBackURL/>
+    <cfset var oReq = oAuthAccessObject(
+      httpURL = variables.instance.reqEndpoint,
+      httpMethod = "POST",
+      parameters = requestParameters
+    )/>
+
+    <cfhttp method="post" url="#variables.instance.reqEndpoint#" charset="utf-8" >
+      <cfhttpparam type="header" name="Authorization" value="#oReq.toHeader(includeHeaderName=false)#" />
+    </cfhttp>
+
+    <cfif findNoCase("oauth_token",cfhttp.filecontent)>
+       <cfset var oauthToken = listlast(listfirst(cfhttp.filecontent,"&"),"=")>
+       <cfset var oauthTokenSecret = listlast(listlast(cfhttp.filecontent,"&"),"=")>
+       <cfset returnStruct['authURL'] = twitterAuthPoint & "?oauth_token=" & oauthToken/>
+       <cfset returnStruct['token'] = oauthToken/>
+       <cfset returnStruct['token_secret'] = oauthTokenSecret/>
+       <cfset returnStruct['success'] = true/>
+    </cfif>
+
+    <cfreturn returnStruct/>
+  </cffunction>
+
 	<cffunction name="getAuthorisation" access="public" output="false" returntype="struct" hint="I make the call to Twitter to request authorisation to access the account.">
 		<cfargument name="callBackURL"	type="string" hint="The URL to hit on call back from authorisation" required="false" default="" />
 		<cfscript>

--- a/com/coldfumonkeh/oauth/oauthrequest.cfc
+++ b/com/coldfumonkeh/oauth/oauthrequest.cfc
@@ -484,6 +484,7 @@ History:
   	<!--- builds the Authorization: header --->
 	<cffunction name="toHeader" access="public" returntype="string" output="false">
 		<cfargument name="sHeaderRealm" default="" required="false" type="string">
+    <cfargument name="includeHeaderName" default=true />
 
 		<cfset var sRealm = arguments.sHeaderRealm>
 		<cfset var sResult = "">
@@ -492,8 +493,10 @@ History:
 		<cfset var aKeys = getParameterKeys()>
 		<cfset var aValues = getParameterValues()>
 
-		<!--- optional realm parameter --->
-		<cfset sResult = """Authorization: OAuth realm=""" & sRealm & """,">
+    <!--- optional realm parameter --->
+    <cfif len(arguments.sHeaderRealm)>
+      <cfset ArrayAppend(aTotal,"""realm=""" & sRealm & """")>
+    </cfif>
 
 		<cfloop from="1" to="#ArrayLen(aKeys)#" index="i">
 			<cfif Left(aKeys[i], 5) EQ "oauth">
@@ -502,7 +505,13 @@ History:
 			</cfif>
 		</cfloop>
 
-		<cfset sResult = sResult & ArrayToList(aTotal, ",")>
+    <cfset sResult = ArrayToList(aTotal, ",")>
+    <cfset sResult = "OAuth #sResult#">
+
+    <cfif arguments.includeHeaderName>
+      <cfset sResult = """Authorization: #sResult#">
+    </cfif>
+
 		<cfreturn sResult>
 	</cffunction>
 


### PR DESCRIPTION
For our use i found it useful to add both a function to get the access to authenticate, and i had to make it optional whether to include the header name in sending the authorization header.

These changes shouldn't affect current uses, if you find them acceptable to include.

Thanks for the fine CFML Twitter library!